### PR TITLE
make clean has error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ $(FILE_A): $(lib_o_files)
 
 clean:
 	$(HOST_RM) src/*.o $(lib_o_files) core $(TARGET) \
-		src/sregex/sre_yyparser.[ch] src/sregex/*.output \
+		src/sregex/*.output \
 		$(FILE_T) $(FILE_SO) $(FILE_A)
 
 test: all


### PR DESCRIPTION
OS: Mac OS X 10.9, Version: github master

step1: make
step2: make clean # remove src/sregex/sre_yyparser.[ch] files
step3: make

output:
BISON     src/sregex/sre_yyparser.h
src/sregex/sre_yyparser.y:60.10-36: syntax error, unexpected string, expecting =
make: **\* [src/sregex/sre_yyparser.h] Error 1
