### PR TITLE
Fix uninstall task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,9 @@ uninstall:
 	$(UNINSTALL) $(INSTALL_T)
 	$(UNINSTALL) $(INSTALL_LIB)/libsregex.so
 	$(UNINSTALL) $(INSTALL_LIB)/libsregex.a
+	$(UNINSTALL) $(INSTALL_SHORT1)
+	$(UNINSTALL) $(INSTALL_SHORT2)
+
 	for file in $(patsubst src/sregex/%,%,$(INSTALL_H_FILES)); do \
 	    $(UNINSTALL) $(INSTALL_INC)/$$file; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ install: all
 
 uninstall:
 	@echo "==== Uninstalling sregex $(VERSION) to $(PREFIX) ===="
-	$(UNINSTALL) $(INSTALL_T)/sregex-cli
+	$(UNINSTALL) $(INSTALL_T)
 	$(UNINSTALL) $(INSTALL_LIB)/libsregex.so
 	$(UNINSTALL) $(INSTALL_LIB)/libsregex.a
 	for file in $(patsubst src/sregex/%,%,$(INSTALL_H_FILES)); do \


### PR DESCRIPTION
When I run `make uninstall`, it raises errors as followings:

```
$ make uninstall

==== Uninstalling sregex 0.0.1 to /usr/local ====
rm -f /usr/local/bin/sregex-cli/sregex-cli
rm: /usr/local/bin/sregex-cli/sregex-cli: Not a directory
make: *** [uninstall] Error 1
```

And I figured out the path of `sregex-cli` is not correct, which I guess should be `/usr/local/bin/sregex-cli` rather than `/usr/local/bin/sregex-cli/sregex-cli`.
