### PR TITLE
silence warning about if guard

### DIFF
--- a/dynasm/dasm_x86.h
+++ b/dynasm/dasm_x86.h
@@ -204,7 +204,8 @@ void dasm_put(Dst_DECL, int start, ...)
       case DASM_SPACE: p++; ofs += n; break;
       case DASM_SETLABEL: b[pos-2] = -0x40000000; break;  /* Neg. label ofs. */
       case DASM_VREG: CK((n&-8) == 0 && (n != 4 || (*p&1) == 0), RANGE_VREG);
-	if (*p++ == 1 && *p == DASM_DISP) mrm = n; continue;
+	if (*p++ == 1 && *p == DASM_DISP) mrm = n;
+	continue;
       }
       mrm = 4;
     } else {


### PR DESCRIPTION
gcc 6.1.1 has this warning at Fedora 24.
I'm not quite sure how to fix this right, now patch does fixes the warning and it should do as previously. So this should be just style without functional change.
```
In file included from src/sregex/sre_vm_thompson_jit.c:16:0:
./dynasm/dasm_x86.h: In function 'dasm_put':
./dynasm/dasm_x86.h:207:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
  if (*p++ == 1 && *p == DASM_DISP) mrm = n; continue;
  ^~
./dynasm/dasm_x86.h:207:45: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
  if (*p++ == 1 && *p == DASM_DISP) mrm = n; continue;
                                             ^~~~~~~~
```