### PR TITLE
Fix memory leaks

### DIFF
--- a/src/sregex/sre_vm_pike.c
+++ b/src/sregex/sre_vm_pike.c
@@ -783,6 +783,7 @@ sre_vm_pike_add_thread(sre_vm_pike_ctx_t *ctx, sre_vm_pike_thread_list_t *l,
             }
         }
 
+        sre_capture_decr_ref(ctx, capture);
         return SRE_OK;
     }
 
@@ -884,6 +885,7 @@ sre_vm_pike_add_thread(sre_vm_pike_ctx_t *ctx, sre_vm_pike_thread_list_t *l,
             goto add;
         }
 
+        sre_capture_decr_ref(ctx, capture);
         break;
 
     case SRE_OPCODE_MATCH:


### PR DESCRIPTION
The original Pike VM has serious memory leak issues and can crash matching just a few megabytes of text. This patch fixes them.
